### PR TITLE
fix: allow float ratio in garbage collector

### DIFF
--- a/transmission-garbagecollect.sh
+++ b/transmission-garbagecollect.sh
@@ -85,7 +85,7 @@ do
       fi
 
       # delete torrents greater than ${RATIO}
-      if [[ "${RATIO}" -ne "0" && "${RATIO}" -ne "" ]] && (( $(echo "${torrent_ratio} ${RATIO}" | awk '{print ($1 > $2)}') )); then
+      if [[ "${RATIO}" != "0" && "${RATIO}" != "" ]] && (( $(echo "${torrent_ratio} ${RATIO}" | awk '{print ($1 > $2)}') )); then
         echo "RATIO ${torrent_ratio}"
         echo "${torrent_label} ${torrent_name}"
         echo ""


### PR DESCRIPTION
This change fix syntax error `invalid arithmetic operator` when `RATIO` is defined as float.